### PR TITLE
Ordinalize (day/date) filter

### DIFF
--- a/lib/trmnl/liquid/filters.rb
+++ b/lib/trmnl/liquid/filters.rb
@@ -2,6 +2,7 @@ require 'action_view'
 require 'date'
 require 'redcarpet'
 require 'tzinfo'
+require 'active_support/core_ext/integer/inflections'
 
 begin
   require 'i18n'
@@ -92,6 +93,12 @@ module TRMNL
             condition.evaluate(@context)
           end
         end || []
+      end
+
+      def ordinalize(date_str, strftime_exp)
+        date = Date.parse(date_str)
+        ordinal_day = date.day.ordinalize
+        date.strftime(strftime_exp.gsub('<<ordinal_day>>', ordinal_day))
       end
 
       private

--- a/spec/trmnl/liquid/filters_spec.rb
+++ b/spec/trmnl/liquid/filters_spec.rb
@@ -97,4 +97,9 @@ describe TRMNL::Liquid::Filters do
     expect_render('{{ "just a string" | where_exp: "la", "le" }}', 'just a string')
     expect_render('{% assign nums = "1, 2, 3, 4, 5" | split: ", " | map_to_i %}{{ nums | where_exp: "n", "n >= 3" }}', '345')
   end
+
+  it 'supports ordinalize' do
+    expect_render('{{ "2025-10-02" | ordinalize: "%A, %B <<ordinal_day>>, %Y" }}', 'Thursday, October 2nd, 2025')
+    expect_render('{{ "2025-12-31 16:50:38 -0400" | ordinalize: "%A, %b <<ordinal_day>>" }}', 'Wednesday, Dec 31st')
+  end
 end


### PR DESCRIPTION
appends ordinal suffix to day of month/year:

```
1 => 1st
2 => 2nd
3 => 3rd
etc 
```

interpolates with results of `strftime()` (accessible standalone as `date:` [Liquid filter](https://help.usetrmnl.com/en/articles/10693981-advanced-liquid)) like so:

```
{{ "2025-10-02" | ordinalize: "%A, %B <<ordinal_day>>, %Y" }} # => Thursday, October 2nd, 2025
{{ "2025-12-31 16:50:38 -0400" | ordinalize: "%A, %b <<ordinal_day>>" }} # => Wednesday, Dec 31st
```

will be documented here:
https://help.usetrmnl.com/en/articles/10347358-custom-plugin-filters