### PR TITLE
Fixed responsive QR codes rendering at zero width

### DIFF
--- a/lib/trmnl/liquid/filters.rb
+++ b/lib/trmnl/liquid/filters.rb
@@ -126,22 +126,29 @@ module TRMNL
         level = "h" unless %w[l m q h].include? level.downcase
 
         qrcode = RQRCode::QRCode.new(data, level:)
+        responsive = view == "responsive"
+
         qrcode.as_svg(
           color: "000",
           fill: "fff",
           shape_rendering: "crispEdges",
           module_size: size,
           use_path: true,
-          viewbox: view == "responsive",
-          svg_attributes: {
-            class: "qr-code"
-          }
+          viewbox: responsive,
+          svg_attributes: {class: "qr-code", **(responsive ? intrinsic_size(qrcode, size) : {})}
         )
       end
       # rubocop:enable Metrics/ParameterLists
       # rubocop:enable Metrics/MethodLength
 
       private
+
+      # RQRCode swaps width and height for a view box, leaving the element with no size of its own
+      def intrinsic_size qrcode, size
+        length = qrcode.qrcode.module_count * size
+
+        {width: length, height: length, style: "max-width:100%;height:auto"}
+      end
 
       def with_i18n fallback
         if defined?(::I18n)

--- a/spec/trmnl/liquid/filters_spec.rb
+++ b/spec/trmnl/liquid/filters_spec.rb
@@ -356,7 +356,10 @@ RSpec.describe TRMNL::Liquid::Filters do
         "xmlns:ev" => "http://www.w3.org/2001/xml-events",
         "shape-rendering" => "crispEdges",
         "class" => "qr-code",
-        "viewBox" => "0 0 231 231"
+        "viewBox" => "0 0 231 231",
+        "width" => "231",
+        "height" => "231",
+        "style" => "max-width:100%;height:auto"
       )
     end
 
@@ -370,7 +373,10 @@ RSpec.describe TRMNL::Liquid::Filters do
         "xmlns:ev" => "http://www.w3.org/2001/xml-events",
         "shape-rendering" => "crispEdges",
         "class" => "qr-code",
-        "viewBox" => "0 0 231 231"
+        "viewBox" => "0 0 231 231",
+        "width" => "231",
+        "height" => "231",
+        "style" => "max-width:100%;height:auto"
       )
     end
 
@@ -384,12 +390,15 @@ RSpec.describe TRMNL::Liquid::Filters do
         "xmlns:ev" => "http://www.w3.org/2001/xml-events",
         "shape-rendering" => "crispEdges",
         "class" => "qr-code",
-        "viewBox" => "0 0 231 231"
+        "viewBox" => "0 0 231 231",
+        "width" => "231",
+        "height" => "231",
+        "style" => "max-width:100%;height:auto"
       )
     end
 
     it "answers SVG with width and height when view box is fixed (disabled)" do
-      template.replace %({{ "Test" | qr_code, 11, "", fixed }})
+      template.replace %({{ "Test" | qr_code: 11, "", "fixed" }})
 
       expect(expectation).to eq(
         "version" => "1.1",


### PR DESCRIPTION
A responsive code is marked with a view box and no width or height, because rqrcode treats the two as alternatives and swaps one for the other. That leaves the element with no size of its own, so wherever the container takes its width from its content the code renders at zero width and is absent from the screen while still present in the markup. This is what a plugin putting a code inside a `flex flex--col flex--center` column sees.

- supplies `width` and `height` alongside the view box for responsive codes
- adds `max-width:100%;height:auto` so a code still shrinks inside a narrower container
- leaves codes asked for with the `fixed` view as they were
- works the dimensions out in a private method that is only called when they are wanted
- quotes the view argument in the fixed view example

Core carries the same change as an initializer so plugins are fixed before this ships. That patch skips elements that already carry a width, so it stops applying once this is released.

On the last bullet, I had the reason wrong first time round and want to correct it rather than leave it standing. I said the example separated the filter arguments with commas and so never passed a view through. That is not what happens — Liquid's lax parser accepts the commas and does pass the arguments:

```
{{ "Test" | qr_code, 11, "", fixed }}    -> size=11 level="" view=nil
{{ "Test" | qr_code: 11, "", "fixed" }}  -> size=11 level="" view="fixed"
{{ "Test" | qr_code: 11, "", banana }}   -> size=11 level="" view=nil
```

The real problem was the bare `fixed`, which Liquid resolves as an undefined variable to `nil`. The example produced a fixed view only because every value other than `responsive` does, so `banana` passes it just as well. Quoting it is still the right fix, but it was demonstrating the fixed view by accident.

Which points at something to settle separately: `level` is validated against a list and falls back to `h`, while `view` is not validated at all, so any unrecognised value silently means fixed. Happy to tighten that here or leave it, but it is a behaviour change rather than a fix so I have left it alone.
